### PR TITLE
support local fs

### DIFF
--- a/priv/ansible/group_vars/development.yml
+++ b/priv/ansible/group_vars/development.yml
@@ -21,6 +21,10 @@ latexmk_src: http://mirror.physik-pool.tu-berlin.de/tex-archive/support/latexmk/
 
 git_repo: git://github.com/sharelatex/sharelatex.git
 
+# datastore: options fs or s3
+
+backend: "fs"
+
 # aws credentials
 
 aws_key: ""

--- a/priv/ansible/roles/sharelatex/templates/settings.development.coffee.j2
+++ b/priv/ansible/roles/sharelatex/templates/settings.development.coffee.j2
@@ -16,20 +16,33 @@ httpAuthUsers[httpAuthUser] = httpAuthPass
 sessionSecret = "secret-please-change"
 
 module.exports =
+
 	# File storage
 	# ------------
 	#
-	# ShareLaTeX stores binary files like images in S3.
-	# Fill in your Amazon S3 credentials below.
-	s3:
-		key: "{{ aws_key }}"
-		secret: "{{ aws_secret }}"
-		buckets:
-			# The S3 bucket name to store binary files in
-			user_files: "{{ aws_bucket }}"
-	
-	# Tell the filestore api to use s3 to persist files, in future more backends can be added
-	filestoreBackend: "s3"
+	# ShareLaTeX needs somewhere to store binary files like images.
+	# There are currently two options:
+	#     Your local filesystem (the default)
+	#     Amazon S3
+	filestore:
+		# which backend persistor to use.
+		# choices are 
+		# s3 - Amazon S3
+		# fs - local filesystem
+		backend: "{{ backend }}"	
+		stores:
+			# where to store user and template binary files
+			#
+			# For Amazon S3 this is the bucket name to store binary files
+			#
+			# For local filesystem this is the directory to store the files in.
+			# This path must exist, not be tmpfs and be writable to by the user sharelatex is run as.
+			user_files: Path.resolve(__dirname + "/../user_files")
+		# Uncomment if you need to configure your S3 credentials
+		# s3:
+		#	# if you are using S3, then fill in your S3 details below
+		# 	key: "{{ aws_key }}"
+		# 	secret: "{{ aws_secret }}"
 
 	# Databases
 	# ---------


### PR DESCRIPTION
This updates the config file to include the new changes to the datastore backend.

The new config file does not have an example on how to use aws as datastore, so I just left everything commented out as in the example config file.
