### PR TITLE
Various updates for recent Vagrant

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,7 @@ Vagrant.configure("2") do |config|
     config.vm.provision "ansible" do |ansible|
       ansible.playbook = "priv/ansible/share_latex.yml"
       ansible.inventory_path = "priv/ansible/dev_hosts"
+      ansible.limit = "all" 
     end
   end
 

--- a/priv/ansible/group_vars/development.yml
+++ b/priv/ansible/group_vars/development.yml
@@ -15,7 +15,7 @@ redis_version: "2.6.16"
 
 # latexmk latest soource
 
-latexmk_src: http://mirror.physik-pool.tu-berlin.de/tex-archive/support/latexmk/latexmk.pl
+latexmk_src: http://mirrors.ctan.org/support/latexmk/latexmk.pl
 
 # sharelatex repo
 

--- a/priv/ansible/group_vars/development.yml
+++ b/priv/ansible/group_vars/development.yml
@@ -5,8 +5,8 @@ app_dir: /webapps/sharelatex
 # nodejs params
 
 node_version: "0.10.26"
-node_prefix: "node-v${node_version}"
-node_tarball: "${node_prefix}.tar.gz"
+node_prefix: "node-v{{ node_version }}"
+node_tarball: "{{node_prefix}}.tar.gz"
 node_path: "/usr/local"
 
 # redis

--- a/priv/ansible/roles/common/tasks/setup.yml
+++ b/priv/ansible/roles/common/tasks/setup.yml
@@ -7,7 +7,7 @@
   template: src=locale dest=/etc/default/locale owner=root group=root mode=644
 
 - name: install packages
-  action: apt pkg=$item state=installed
+  action: apt pkg={{ item }} state=installed
   with_items:
     - build-essential
     - automake


### PR DESCRIPTION
These commits make several small changes that I needed to make to get this Vagrant box to work for me with Vagrant-1.6.0 and ansible-1.5.5, without depreciation warnings.

I also changed the latexmk url to a globally accessible address.
